### PR TITLE
More strict manifest discovery regex

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 # launch setup
 setup(
     name = 'pyats-image-builder',
-    version = '21.5',
+    version = '21.5.1',
 
     # descriptions
     description = 'pyATS Docker image creation',

--- a/src/pyatsimagebuilder/utils.py
+++ b/src/pyatsimagebuilder/utils.py
@@ -19,9 +19,9 @@ logger.addHandler(logging.StreamHandler(sys.stdout))
 PYATS_ANCHOR = 'PYATS_JOBFILE'
 
 DEFAULT_JOB_REGEXES = [
-    r'.*job.*\.py',
+    r'.*job.*\.py$',
 ]
-MANIFEST_REGEX = [r'.*\.tem']
+MANIFEST_REGEX = [r'.*\.tem$']
 MANIFEST_VERSION = 1
 
 


### PR DESCRIPTION
files must end in .tem, should not match .template files