### PR TITLE
Update manifest discovery to handle missing data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ clean:
 
 develop:
 	@echo "--------------------------------------------------------------------"
+	@echo "Uninstalling package"
+	@pip uninstall -y pyats-image-builder
 	@echo "Installing development dependencies"
 	@pip install $(DEPENDENCIES)
 	@echo ""

--- a/src/pyatsimagebuilder/utils.py
+++ b/src/pyatsimagebuilder/utils.py
@@ -429,14 +429,17 @@ def discover_manifests(search_path, ignore_folders=None, relative_path=None,
                 break
 
         manifest_data['run_type'] = 'manifest'
-        manifest_data['job_type'] = manifest_data.pop('type')
+        manifest_data['job_type'] = manifest_data.pop('type', None)
+        if not manifest_data['job_type']:
+            logger.warning(f'No job type specified in {manifest}')
+            continue
 
         # Pop runtimes and profiles to add them back later as lists
         runtimes = manifest_data.pop('runtimes', {})
         profiles = manifest_data.pop('profiles', {})
 
         # Create default profile from top level arguments and system environment
-        default_arguments = manifest_data.pop('arguments')
+        default_arguments = manifest_data.pop('arguments', {})
         default_runtime = runtimes.get('system', {})
         default_environment = default_runtime.get('environment', {})
         profiles['DEFAULT'] = {}


### PR DESCRIPTION
If manifest file is missing `type` field, discovery would break.   This PR fixes that and sets a default of None for type and uses an empty dictionary as default arguments.

If a manifest is missing `type`, a warning is logged

...
Discovering Manifests
No job type specified in /tmp/pyats-image.s9zs9hhb/examples/connection/connection_example_job.tem
...
