### PR TITLE
Bastell discovery subset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ install:
 	@echo "Installing dependencies"
 	@pip install $(DEPENDENCIES)
 	@echo "Installing package"
-	@python setup.py install
+	@python3 setup.py install
 	@echo ""
 	@echo "Done."
 	@echo ""
@@ -35,7 +35,7 @@ package:
 	@echo "--------------------------------------------------------------------"
 	@echo "Building package"
 	@mkdir -p $(DIST_DIR)/
-	@python setup.py bdist_wheel --dist-dir=$(DIST_DIR)
+	@python3 setup.py bdist_wheel --dist-dir=$(DIST_DIR)
 	@echo ""
 	@echo "Done."
 	@echo ""
@@ -43,7 +43,7 @@ package:
 clean:
 	@echo ""
 	@echo "--------------------------------------------------------------------"
-	@python setup.py clean
+	@python3 setup.py clean
 	@echo "Removing *.pyc and __pycache__/ files"
 	@find . -type f -name "*.pyc" | xargs rm -vrf
 	@find . -type d -name "__pycache__" | xargs rm -vrf
@@ -60,7 +60,7 @@ develop:
 	@echo ""
 	@echo "--------------------------------------------------------------------"
 	@echo "Setting up development environment"
-	@python setup.py develop --no-deps -q
+	@python3 setup.py develop --no-deps -q
 	@echo ""
 	@echo "Done."
 	@echo ""
@@ -69,7 +69,7 @@ undevelop:
 	@echo ""
 	@echo "--------------------------------------------------------------------"
 	@echo "Removing development environment"
-	@python setup.py develop -q --no-deps --uninstall
+	@python3 setup.py develop -q --no-deps --uninstall
 	@echo ""
 	@echo "Done."
 	@echo ""

--- a/src/pyatsimagebuilder/__init__.py
+++ b/src/pyatsimagebuilder/__init__.py
@@ -2,5 +2,5 @@ from .image import Image
 from .builder import ImageBuilder
 
 # metadata
-__version__ = '24.6'
+__version__ = '24.7.1'
 __author__ = 'Cisco Systems Inc.'

--- a/src/pyatsimagebuilder/__init__.py
+++ b/src/pyatsimagebuilder/__init__.py
@@ -2,5 +2,5 @@ from .image import Image
 from .builder import ImageBuilder
 
 # metadata
-__version__ = '24.7.1'
+__version__ = '24.7.2'
 __author__ = 'Cisco Systems Inc.'

--- a/src/pyatsimagebuilder/__init__.py
+++ b/src/pyatsimagebuilder/__init__.py
@@ -2,5 +2,5 @@ from .image import Image
 from .builder import ImageBuilder
 
 # metadata
-__version__ = '24.5'
+__version__ = '24.6'
 __author__ = 'Cisco Systems Inc.'

--- a/src/pyatsimagebuilder/__init__.py
+++ b/src/pyatsimagebuilder/__init__.py
@@ -2,5 +2,5 @@ from .image import Image
 from .builder import ImageBuilder
 
 # metadata
-__version__ = '24.4'
+__version__ = '24.5'
 __author__ = 'Cisco Systems Inc.'

--- a/src/pyatsimagebuilder/context.py
+++ b/src/pyatsimagebuilder/context.py
@@ -19,12 +19,12 @@ class Context(object):
         self.path = None
         self.keep = keep
 
-    def mkdir(self, name):
+    def mkdir(self, name, exist_ok=False):
         '''
         create a folder in this build context
         '''
         folder = self.path / name
-        folder.mkdir()
+        folder.mkdir(parents=True, exist_ok=exist_ok)
         return folder.relative_to(self.path)
 
     def write_file(self, file, content):

--- a/src/pyatsimagebuilder/utils.py
+++ b/src/pyatsimagebuilder/utils.py
@@ -348,6 +348,8 @@ def discover_jobs(jobfiles,
 
 
 def parse_manifests(manifests, search_path, relative_path=None, repo_data=None):
+    if repo_data is None:
+        repo_data = {}
     jobs = []
     for manifest in manifests:
         try:

--- a/src/pyatsimagebuilder/utils.py
+++ b/src/pyatsimagebuilder/utils.py
@@ -427,7 +427,7 @@ def parse_manifests(manifests, search_path, relative_path=None, repo_data=None):
         repo_data = {}
     jobs = []
 
-    with ThreadPoolExecutor(max_workers=50) as executor:
+    with ThreadPoolExecutor(max_workers=15) as executor:
         for manifest in manifests:
             executor.submit(parse_manifest, manifest, jobs, search_path, relative_path, repo_data)
 
@@ -622,7 +622,7 @@ def discover_yamls(manifests, search_path, relative_path=None):
         relative_path (str): String with the directory search results will be relative to
     """
     logger.info('Discovering YAML files from manifests')
-    with ThreadPoolExecutor(max_workers=50) as executor:
+    with ThreadPoolExecutor(max_workers=15) as executor:
         for manifest in manifests:
             executor.submit(discover_yamls_from_manifest,
                             manifest,

--- a/src/pyatsimagebuilder/utils.py
+++ b/src/pyatsimagebuilder/utils.py
@@ -508,8 +508,8 @@ def _process_testbed_file(profile, yaml_contents):
                     if dev.get(key):
                         testbed_info[dev_name][key] = dev[key]
                 if dev.get('connections', {}).get('a'):
-                    port = dev[key]['a'].get('port')
-                    ip = dev[key]['a'].get('ip')
+                    port = dev['connections']['a'].get('port')
+                    ip = dev['connections']['a'].get('ip')
                     if ip and port:
                         testbed_info[dev_name]['console'] = f'{ip}:{port}'
 


### PR DESCRIPTION
Allow for discovery against a subset of manifest files. This will allow images to be built with only changed files being discovered between image layers.
Also enables threading for file parsing.